### PR TITLE
Fixing PATH environment settings

### DIFF
--- a/config.nu
+++ b/config.nu
@@ -5,6 +5,8 @@
 # See https://www.nushell.sh/book/configuration.html
 #
 
+$env.PATH = ( $env.PATH | split row ( char esep) )
+
 export-env {
     $env.EDITOR = 'nvim'
     $env.REPO_HOME = ( $nu.home-path + '/source/repos' )

--- a/modules/macos/mod.nu
+++ b/modules/macos/mod.nu
@@ -3,15 +3,12 @@
 export-env {
     $env.HOMEBREW_CELLAR = '/opt/homebrew/Cellar'
     $env.HOMEBREW_REPOSITORY = '/opt/homebrew'
-    $env.PATH = (
-        $env.PATH |
-        append [
-            '/opt/homebrew/bin'
-            '/opt/homebrew/sbin'
-            '/usr/bin'
-            '/bin'
-            '/usr/sbin'
-            '/sbin'
-        ]
-    )
+    $env.PATH = $env.PATH | append [
+        '/opt/homebrew/bin'
+        '/opt/homebrew/sbin'
+        '/usr/bin'
+        '/bin'
+        '/usr/sbin'
+        '/sbin'
+    ]
 }

--- a/modules/oracle/mod.nu
+++ b/modules/oracle/mod.nu
@@ -4,5 +4,5 @@ export-env {
     $env.ORACLE_BASE = $env.HOME + '/.local/oracle'
     $env.SQLPATH = $env.ORACLE_BASE + '/sql'
     $env.TNS_ADMIN = $env.ORACLE_BASE + '/network/admin'
-    $env.PATH = $env.PATH + ( char esep ) + $env.ORACLE_BASE + '/product/sqlcl/bin'
+    $env.PATH = $env.PATH | append ( $env.ORACLE_BASE + '/product/sqlcl/bin' )
 }

--- a/modules/oracle/mod.nu
+++ b/modules/oracle/mod.nu
@@ -4,9 +4,5 @@ export-env {
     $env.ORACLE_BASE = $env.HOME + '/.local/oracle'
     $env.SQLPATH = $env.ORACLE_BASE + '/sql'
     $env.TNS_ADMIN = $env.ORACLE_BASE + '/network/admin'
-    $env.PATH = (
-        $env.PATH | append [
-            ( $env.ORACLE_BASE + '/product/sqlcl/bin' )
-        ]
-    )
+    $env.PATH = $env.PATH + ( char esep ) + $env.ORACLE_BASE + '/product/sqlcl/bin'
 }

--- a/modules/rust/mod.nu
+++ b/modules/rust/mod.nu
@@ -1,6 +1,6 @@
 # Customizations for Rust
 
 export-env {
-    $env.PATH = ( $env.PATH | append ( $env.HOME + "/.cargo/bin" ) )
+    $env.PATH = $env.PATH + ( char esep ) + $env.HOME + "/.cargo/bin"
     $env.RUSTC_WRAPPER = "sccache"
 }

--- a/modules/rust/mod.nu
+++ b/modules/rust/mod.nu
@@ -1,6 +1,6 @@
 # Customizations for Rust
 
 export-env {
-    $env.PATH = $env.PATH + ( char esep ) + $env.HOME + "/.cargo/bin"
+    $env.PATH = $env.PATH | append ( $env.HOME + "/.cargo/bin" )
     $env.RUSTC_WRAPPER = "sccache"
 }


### PR DESCRIPTION
Setting $env.PATH explicitly to a list<string> so extending it will be more standardized across Operating Systems

### Commit summaries
- **Updating PATH export in Oracle and Rust modules**
- **Trying a different approach for setting PATH**
